### PR TITLE
replace get_pid to pid, fix warning elixir 1.15.4

### DIFF
--- a/lib/ink.ex
+++ b/lib/ink.ex
@@ -183,7 +183,7 @@ defmodule Ink do
        when is_binary(message) do
     %{
       name: name(),
-      pid: System.get_pid() |> String.to_integer(),
+      pid: System.pid() |> String.to_integer(),
       msg: message,
       time: formatted_timestamp(timestamp),
       level: level(level, config.status_mapping),


### PR DESCRIPTION
fix https://github.com/doofinder/stats/issues/553


![image](https://github.com/ivx/ink/assets/20560227/64c9b79c-224d-4baa-920e-d6324499bcb2)
